### PR TITLE
removed redundant coroutine adapter | added try catch in network call

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -112,7 +112,6 @@ dependencies {
 
     // Retrofit
     implementation "com.squareup.retrofit2:retrofit:$version_retrofit"
-    implementation "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:$version_retrofit_coroutines_adapter"
     implementation "com.google.code.gson:gson:$version_gson"
     implementation "com.squareup.retrofit2:converter-gson:$version_retrofit_gson_adapter"
     implementation "com.squareup.okhttp3:logging-interceptor:$version_retrofit_log"

--- a/app/src/main/java/org/merakilearn/datasource/ApplicationRepo.kt
+++ b/app/src/main/java/org/merakilearn/datasource/ApplicationRepo.kt
@@ -29,8 +29,7 @@ class ApplicationRepo(
             if (isFakeLogin) {
                 loginRequest.id = AppUtils.getFakeLoginResponseId(application)
             }
-            val req = applicationApi.initLoginAsync(loginRequest)
-            val response = req.await()
+            val response = applicationApi.initLoginAsync(loginRequest)
             AppUtils.saveUserLoginResponse(response, application)
             authenticationRepository.login(response.user.chatId, response.user.chatPassword)
             if (isFakeLogin)
@@ -48,8 +47,7 @@ class ApplicationRepo(
 
     suspend fun fetchOtherCourseData(): List<Course>? {
         return try {
-            val req = applicationApi.getRecommendedCourseAsync(AppUtils.getAuthToken(application))
-            val response = req.await()
+            val response = applicationApi.getRecommendedCourseAsync(AppUtils.getAuthToken(application))
             response.forEachIndexed { index, course ->
                 course.number = (index + 1)
             }
@@ -60,11 +58,10 @@ class ApplicationRepo(
         }
     }
 
-    suspend fun fetchUpcomingClassData(): List<Classes>? {
+    suspend fun fetchUpcomingClassData(): List<Classes> {
         return try {
-            val req = applicationApi.getUpComingClassesAsync(AppUtils.getAuthToken(application))
-            val response = req?.await()
-            response?.classes
+            val response = applicationApi.getUpComingClassesAsync(AppUtils.getAuthToken(application))
+            response.classes
         } catch (ex: Exception) {
             Log.e(TAG, "fetchUpcomingClassData: ", ex)
             mutableListOf()
@@ -72,10 +69,9 @@ class ApplicationRepo(
 
     }
 
-    suspend fun fetchMyClassData(): List<MyClass?>? {
+    suspend fun fetchMyClassData(): List<MyClass> {
         return try {
-            val req = applicationApi.getMyClassesAsync(AppUtils.getAuthToken(application))
-            val response = req.await()
+            val response = applicationApi.getMyClassesAsync(AppUtils.getAuthToken(application))
             response
         } catch (ex: Exception) {
             Log.e(TAG, "fetchUpcomingClassData: ", ex)
@@ -86,11 +82,10 @@ class ApplicationRepo(
 
     suspend fun fetchClassData(classId: String?): Classes? {
         return try {
-            val req = applicationApi.fetchClassDataAsync(
+            val response = applicationApi.fetchClassDataAsync(
                 AppUtils.getAuthToken(application),
                 classId?.toIntOrNull()
             )
-            val response = req.await()
             response
         } catch (ex: Exception) {
             Log.e(TAG, "fetchUpcomingClassData: ", ex)
@@ -100,16 +95,14 @@ class ApplicationRepo(
 
     suspend fun enrollToClass(classId: Int, enrolled: Boolean): Boolean {
         return try {
-            val req: Deferred<ResponseBody>
             if (enrolled) {
-                req = applicationApi.logOutToClassAsync(AppUtils.getAuthToken(application), classId)
+                applicationApi.logOutToClassAsync(AppUtils.getAuthToken(application), classId)
             } else {
-                req = applicationApi.enrollToClassAsync(
+                applicationApi.enrollToClassAsync(
                     AppUtils.getAuthToken(application), classId,
                     mutableMapOf()
                 )
             }
-            val response = req.await()
             true
         } catch (ex: Exception) {
             Log.e(TAG, "enrollToClass: ", ex)
@@ -119,8 +112,7 @@ class ApplicationRepo(
 
     suspend fun performFakeSignUp(): LoginResponse? {
         return try {
-            val req = applicationApi.initFakeSignUpAsync()
-            val response = req.await()
+            val response = applicationApi.initFakeSignUpAsync()
             AppUtils.saveFakeLoginResponse(response, application)
             authenticationRepository.login(response.user.chatId, response.user.chatPassword)
             response
@@ -132,12 +124,10 @@ class ApplicationRepo(
 
     suspend fun updateProfile(user: LoginResponse.User): Boolean {
         return try {
-
-            val req = applicationApi.initUserUpdateAsync(
+            val response = applicationApi.initUserUpdateAsync(
                 AppUtils.getAuthToken(application),
                 UserUpdate(user.name)
             )
-            val response = req.await()
             AppUtils.saveUserResponse(response.user ,application)
             true
         } catch (ex: Exception) {

--- a/app/src/main/java/org/merakilearn/datasource/network/SaralApi.kt
+++ b/app/src/main/java/org/merakilearn/datasource/network/SaralApi.kt
@@ -1,6 +1,5 @@
 package org.merakilearn.datasource.network
 
-import kotlinx.coroutines.Deferred
 import okhttp3.ResponseBody
 import org.merakilearn.datasource.network.model.*
 import org.navgurukul.learn.courses.db.models.Course
@@ -9,42 +8,42 @@ import retrofit2.http.*
 
 interface SaralApi {
     @POST("users/auth/google")
-    fun initLoginAsync(@Body loginRequest: LoginRequest): Deferred<LoginResponse>
+    suspend fun initLoginAsync(@Body loginRequest: LoginRequest): LoginResponse
 
     @GET("classes/upcoming")
-    fun getUpComingClassesAsync(@Header(value = "Authorization") token: String?): Deferred<ClassesContainer?>?
+    suspend fun getUpComingClassesAsync(@Header(value = "Authorization") token: String?): ClassesContainer
 
     @GET("courses/recommended")
-    fun getRecommendedCourseAsync(@Header(value = "Authorization") token: String?): Deferred<List<Course>>
+    suspend fun getRecommendedCourseAsync(@Header(value = "Authorization") token: String?): List<Course>
 
     @GET("classes")
-    fun getMyClassesAsync(@Header(value = "Authorization") token: String?): Deferred<List<MyClass>>
+    suspend fun getMyClassesAsync(@Header(value = "Authorization") token: String?): List<MyClass>
 
     @POST("classes/{classId}/register")
-    fun enrollToClassAsync(
+    suspend fun enrollToClassAsync(
         @Header(value = "Authorization") token: String?,
         @Path(value = "classId") classId: Int,
         @Body hashMap: MutableMap<String, Any>
-    ): Deferred<ResponseBody>
+    ): ResponseBody
 
     @DELETE("classes/{classId}/unregister")
-    fun logOutToClassAsync(
+    suspend fun logOutToClassAsync(
         @Header(value = "Authorization") token: String?,
         @Path(value = "classId") classId: Int
-    ): Deferred<ResponseBody>
+    ): ResponseBody
 
     @POST("users/create")
-    fun initFakeSignUpAsync(): Deferred<LoginResponse>
+    suspend fun initFakeSignUpAsync(): LoginResponse
 
     @PUT("users/me")
-    fun initUserUpdateAsync(
+    suspend fun initUserUpdateAsync(
         @Header(value = "Authorization") token: String?,
         @Body loginResponse: UserUpdate
-    ): Deferred<UserUpdateContainer>
+    ): UserUpdateContainer
 
     @GET("classes/{classId}")
-    fun fetchClassDataAsync(
+    suspend fun fetchClassDataAsync(
         @Header(value = "Authorization") token: String?,
         @Path(value = "classId") classId: Int?
-    ): Deferred<Classes>
+    ): Classes
 }

--- a/app/src/main/java/org/merakilearn/di/Modules.kt
+++ b/app/src/main/java/org/merakilearn/di/Modules.kt
@@ -3,7 +3,6 @@ package org.merakilearn.di
 import android.app.Application
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
-import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -65,7 +64,6 @@ val networkModule = module {
         return Retrofit.Builder()
             .baseUrl(BuildConfig.SERVER_URL)
             .addConverterFactory(GsonConverterFactory.create(factory))
-            .addCallAdapterFactory(CoroutineCallAdapterFactory())
             .client(client)
             .build()
     }

--- a/learn/build.gradle
+++ b/learn/build.gradle
@@ -61,7 +61,6 @@ dependencies {
 
     // Retrofit
     implementation "com.squareup.retrofit2:retrofit:$version_retrofit"
-    implementation "com.jakewharton.retrofit:retrofit2-kotlin-coroutines-adapter:$version_retrofit_coroutines_adapter"
     implementation "com.google.code.gson:gson:$version_gson"
     implementation "com.squareup.retrofit2:converter-gson:$version_retrofit_gson_adapter"
     implementation "com.squareup.okhttp3:logging-interceptor:$version_retrofit_log"

--- a/learn/src/main/java/org/navgurukul/learn/courses/network/NetworkBoundResource.kt
+++ b/learn/src/main/java/org/navgurukul/learn/courses/network/NetworkBoundResource.kt
@@ -20,8 +20,7 @@ abstract class NetworkBoundResource<ResultType, RequestType> {
     private suspend fun fetchFromNetwork(dbSource: ResultType?) {
         dbSource?.let(result::postValue)
         try {
-            val apiResponse = makeApiCallAsync()
-            val data = apiResponse.await()
+            val data = makeApiCallAsync()
             saveCallResult(data)
             result.postValue(loadFromDb())
         } catch (e: Exception) {
@@ -34,7 +33,7 @@ abstract class NetworkBoundResource<ResultType, RequestType> {
 
     protected abstract fun shouldFetch(data: ResultType?): Boolean
 
-    protected abstract suspend fun makeApiCallAsync(): Deferred<RequestType>
+    protected abstract suspend fun makeApiCallAsync(): RequestType
 
     protected abstract suspend fun saveCallResult(data: RequestType)
 

--- a/learn/src/main/java/org/navgurukul/learn/courses/network/SaralCoursesApi.kt
+++ b/learn/src/main/java/org/navgurukul/learn/courses/network/SaralCoursesApi.kt
@@ -1,6 +1,5 @@
 package org.navgurukul.learn.courses.network
 
-import kotlinx.coroutines.Deferred
 import org.navgurukul.learn.courses.network.model.CourseExerciseContainer
 import org.navgurukul.learn.courses.network.model.PathWayCourseContainer
 import retrofit2.http.GET
@@ -10,9 +9,9 @@ import retrofit2.http.Path
 
 interface SaralCoursesApi {
     @GET("/pathways/courses")
-    fun getDefaultPathwayCoursesAsync(@Header(value = "Authorization") token: String?): Deferred<PathWayCourseContainer>
+    suspend fun getDefaultPathwayCoursesAsync(@Header(value = "Authorization") token: String?): PathWayCourseContainer
 
     @GET("/courses/{course_id}/exercises")
-    fun getExercisesAsync(@Path("course_id") course_id: String): Deferred<CourseExerciseContainer>
+    suspend fun getExercisesAsync(@Path("course_id") course_id: String): CourseExerciseContainer
 
 }


### PR DESCRIPTION
- coroutine adapter was redundant as retrofit has inbuilt support for coroutines. This PR removes adapter
- Added try catch around a network request which was resulting in a crash