### PR TITLE
Pushers Update crash fix

### DIFF
--- a/chat/src/main/java/org/navgurukul/chat/core/pushers/PushersManager.kt
+++ b/chat/src/main/java/org/navgurukul/chat/core/pushers/PushersManager.kt
@@ -5,7 +5,6 @@ import org.navgurukul.chat.R
 import org.navgurukul.chat.core.repo.ActiveSessionHolder
 import org.navgurukul.chat.core.resources.LocaleProvider
 import org.navgurukul.commonui.resources.StringProvider
-import java.util.*
 import kotlin.math.abs
 
 private const val DEFAULT_PUSHER_FILE_TAG = "mobile"
@@ -16,11 +15,11 @@ class PushersManager(
     private val stringProvider: StringProvider
 ) {
 
-    fun registerPusherWithFcmKey(pushKey: String): UUID {
-        val currentSession = activeSessionHolder.getActiveSession()
+    fun registerPusherWithFcmKey(pushKey: String) {
+        val currentSession = activeSessionHolder.getSafeActiveSession() ?: return
         val profileTag = DEFAULT_PUSHER_FILE_TAG + "_" + abs(currentSession.myUserId.hashCode())
 
-        return currentSession.addHttpPusher(
+        currentSession.addHttpPusher(
                 pushKey,
                 stringProvider.getString(R.string.pusher_app_id),
                 profileTag,


### PR DESCRIPTION
Active session can be null in cases FCM token is update while the user was logged out. This crash was reported on Crashlytics. This PR adds a null check on active session to fix the crash